### PR TITLE
Add structure-pick curation workflow (per-curator overrides + picker …

### DIFF
--- a/Scripts/Structures/Curate_Structure_Pick.py
+++ b/Scripts/Structures/Curate_Structure_Pick.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Interactively curate the chosen structure for a ModelSEED compound.
+
+Records the curator's decision in a per-curator TSV at
+  Biochemistry/Curation/overrides/structure_picks/<curator>.tsv
+which List_ModelSEED_Structures.py reads on its next run to honor
+the manual pick instead of falling back to its DB-cascade tiebreaker.
+
+Usage:
+  python3 Curate_Structure_Pick.py <cpd_id>
+  python3 Curate_Structure_Pick.py <cpd_id> --curator samseaver
+  python3 Curate_Structure_Pick.py <cpd_id> --rationale "matches Lit ref ..."
+
+Prompts for:
+  - Which source's structure to pick (or custom paste)
+  - Rationale (one line of free text)
+"""
+
+import argparse
+import csv
+import datetime
+import getpass
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.normpath(os.path.join(SCRIPT_DIR, '..', '..'))
+ALL_FILE = os.path.join(REPO_ROOT, 'Biochemistry', 'Structures',
+                        'All_ModelSEED_Structures.txt')
+UNIQUE_FILE = os.path.join(REPO_ROOT, 'Biochemistry', 'Structures',
+                           'Unique_ModelSEED_Structures.txt')
+PICK_REASONS_FILE = os.path.join(REPO_ROOT, 'Biochemistry', 'Structures',
+                                 'Pick_Reasons.txt')
+NAMES_FILE = os.path.join(REPO_ROOT, 'Biochemistry', 'Aliases',
+                          'Unique_ModelSEED_Compound_Names.txt')
+OVERRIDES_DIR = os.path.join(REPO_ROOT, 'Biochemistry', 'Curation',
+                             'overrides', 'structure_picks')
+
+HEADER = ['cpd_id', 'format', 'structure', 'source_db', 'source_id',
+          'date', 'rationale']
+
+
+def load_all_for_compound(cpd_id):
+    """Return list of dicts: candidate source rows for the compound,
+    filtered to InChI/Charged rows (the picker's preference order)."""
+    candidates = []
+    with open(ALL_FILE) as fh:
+        for row in csv.reader(fh, delimiter='\t'):
+            if len(row) < 8 or row[0] != cpd_id:
+                continue
+            # row: cpd_id, type, stage, source_id, source_db, formula, charge, structure
+            candidates.append({
+                'type': row[1], 'stage': row[2], 'source_id': row[3],
+                'source_db': row[4], 'formula': row[5], 'charge': row[6],
+                'structure': row[7],
+            })
+    return candidates
+
+
+def load_unique_for_compound(cpd_id):
+    """Return dict {type: structure} from Unique file."""
+    result = {}
+    with open(UNIQUE_FILE) as fh:
+        next(fh)
+        for row in csv.reader(fh, delimiter='\t'):
+            if len(row) < 6 or row[0] != cpd_id:
+                continue
+            result[row[1]] = {'structure': row[5], 'formula': row[3],
+                              'charge': row[4]}
+    return result
+
+
+def load_current_pick_reason(cpd_id):
+    if not os.path.isfile(PICK_REASONS_FILE):
+        return None
+    with open(PICK_REASONS_FILE) as fh:
+        next(fh)
+        for row in csv.reader(fh, delimiter='\t'):
+            if len(row) < 4 or row[0] != cpd_id:
+                continue
+            return row[3]
+    return None
+
+
+def load_names(cpd_id, max_n=3):
+    if not os.path.isfile(NAMES_FILE):
+        return []
+    names = []
+    with open(NAMES_FILE) as fh:
+        next(fh)
+        for line in fh:
+            parts = line.rstrip('\n').split('\t')
+            if len(parts) >= 2 and parts[0] == cpd_id:
+                names.append(parts[1])
+                if len(names) >= max_n:
+                    break
+    return names
+
+
+def append_pick(curator_file, row):
+    """Append a row to the curator's TSV. Creates the file with header
+    if it doesn't exist. Returns True if appended, False if user
+    declined to overwrite an existing entry."""
+    os.makedirs(os.path.dirname(curator_file), exist_ok=True)
+    existing_rows = []
+    if os.path.isfile(curator_file):
+        with open(curator_file) as fh:
+            reader = csv.DictReader(fh, delimiter='\t')
+            existing_rows = list(reader)
+        for er in existing_rows:
+            if er.get('cpd_id') == row['cpd_id']:
+                print(f"\nNote: {row['cpd_id']} already curated by you on "
+                      f"{er.get('date')}.")
+                print(f"  Existing rationale: {er.get('rationale')}")
+                resp = input("Overwrite with new pick? [y/N]: ").strip().lower()
+                if resp != 'y':
+                    return False
+                existing_rows = [r for r in existing_rows
+                                 if r.get('cpd_id') != row['cpd_id']]
+                break
+    existing_rows.append(row)
+    with open(curator_file, 'w', newline='') as fh:
+        writer = csv.DictWriter(fh, fieldnames=HEADER, delimiter='\t',
+                                lineterminator='\n')
+        writer.writeheader()
+        for r in existing_rows:
+            writer.writerow({k: r.get(k, '') for k in HEADER})
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Interactively curate a ModelSEED compound's structure pick")
+    parser.add_argument('cpd_id', help='ModelSEED compound ID (e.g. cpd02168)')
+    parser.add_argument('--curator', default=None,
+                        help='Curator handle (defaults to $USER)')
+    parser.add_argument('--rationale', default=None,
+                        help='Rationale (prompted interactively if omitted)')
+    args = parser.parse_args()
+
+    cpd_id = args.cpd_id
+    curator = args.curator or getpass.getuser()
+    today = datetime.date.today().isoformat()
+
+    # Show current state
+    print(f"\nCompound: {cpd_id}")
+    names = load_names(cpd_id)
+    if names:
+        print(f"Names: {' | '.join(names)}")
+    current = load_unique_for_compound(cpd_id)
+    reason = load_current_pick_reason(cpd_id)
+    if current:
+        print(f"Currently in Unique:")
+        for typ in ('InChI', 'InChIKey', 'SMILE'):
+            if typ in current:
+                s = current[typ]['structure']
+                disp = s if len(s) <= 90 else s[:87] + '...'
+                print(f"  {typ:8}  {disp}")
+        if reason:
+            print(f"  Pick reason: {reason}")
+    else:
+        print(f"  (not currently in Unique file)")
+
+    # Show candidate sources, grouped by (source_db, source_id) pair
+    candidates = load_all_for_compound(cpd_id)
+    if not candidates:
+        print(f"\nNo source rows found for {cpd_id} in All file.")
+        return 1
+
+    # We curate at the InChI/Charged level (picker's preferred type/stage);
+    # fall back to SMILE/Charged if no InChI Charged row exists.
+    preferred = [c for c in candidates if c['type'] == 'InChI'
+                 and c['stage'] == 'Charged']
+    if not preferred:
+        preferred = [c for c in candidates if c['type'] == 'SMILE'
+                     and c['stage'] == 'Charged']
+    if not preferred:
+        print(f"\nNo InChI or SMILE Charged-stage rows for {cpd_id}.")
+        return 1
+
+    print(f"\nCandidate {preferred[0]['type']}/Charged structures:")
+    for i, c in enumerate(preferred, 1):
+        s = c['structure']
+        disp = s if len(s) <= 70 else s[:67] + '...'
+        print(f"  [{i}] {c['source_db']:8} {c['source_id']:12} {disp}")
+    print(f"  [c] custom (paste your own InChI or SMILES)")
+    print(f"  [q] quit without recording")
+
+    choice = input("\nChoice: ").strip().lower()
+    if choice == 'q':
+        print("Aborted.")
+        return 0
+
+    if choice == 'c':
+        fmt = input("Format [InChI/SMILE]: ").strip()
+        if fmt not in ('InChI', 'SMILE'):
+            print(f"Invalid format: {fmt}")
+            return 1
+        struct = input(f"Paste {fmt}: ").strip()
+        if not struct:
+            print("Empty structure; aborted.")
+            return 1
+        source_db = 'custom'
+        source_id = 'custom'
+    else:
+        try:
+            idx = int(choice) - 1
+            chosen = preferred[idx]
+        except (ValueError, IndexError):
+            print(f"Invalid choice: {choice}")
+            return 1
+        fmt = chosen['type']
+        struct = chosen['structure']
+        source_db = chosen['source_db']
+        source_id = chosen['source_id']
+
+    rationale = args.rationale
+    if rationale is None:
+        rationale = input("Rationale (one line): ").strip()
+    if not rationale:
+        print("Rationale required; aborted.")
+        return 1
+
+    row = {
+        'cpd_id': cpd_id,
+        'format': fmt,
+        'structure': struct,
+        'source_db': source_db,
+        'source_id': source_id,
+        'date': today,
+        'rationale': rationale,
+    }
+    curator_file = os.path.join(OVERRIDES_DIR, f'{curator}.tsv')
+    if append_pick(curator_file, row):
+        print(f"\nWrote pick to {curator_file}:")
+        print(f"  {cpd_id}  {fmt}  {source_db}:{source_id}  {rationale[:60]}")
+        print(f"\nNext: re-run Scripts/Structures/List_ModelSEED_Structures.py")
+        print(f"      to regenerate Unique_ModelSEED_Structures.txt with this pick honored.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Scripts/Structures/List_ModelSEED_Structures.py
+++ b/Scripts/Structures/List_ModelSEED_Structures.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import csv
 import json
 import glob
 
@@ -9,6 +10,104 @@ import glob
 #################################################################
 sys.path.append('../../Libs/Python')
 from BiochemPy import Compounds
+
+
+#################################################################
+## Curated structure picks (manual overrides)
+#################################################################
+
+def load_curated_picks():
+    """Read all *.tsv files under Biochemistry/Curation/overrides/structure_picks/
+    and return {cpd_id: {format, structure, source_db, source_id, curator,
+                          date, rationale}}.
+
+    Each TSV file's name is the curator (e.g. samseaver.tsv). Last-write-
+    wins if a compound appears in multiple curator files; warns on overlap.
+    """
+    picks = {}
+    overrides_dir = os.path.join(
+        os.path.dirname(__file__), '..', '..',
+        'Biochemistry', 'Curation', 'overrides', 'structure_picks')
+    overrides_dir = os.path.normpath(overrides_dir)
+    if not os.path.isdir(overrides_dir):
+        return picks
+    for path in sorted(glob.glob(os.path.join(overrides_dir, '*.tsv'))):
+        curator = os.path.splitext(os.path.basename(path))[0]
+        with open(path) as fh:
+            reader = csv.DictReader(fh, delimiter='\t')
+            for row in reader:
+                cpd_id = row.get('cpd_id', '').strip()
+                if not cpd_id:
+                    continue
+                if cpd_id in picks and picks[cpd_id]['curator'] != curator:
+                    print(f"WARN: cpd {cpd_id} curated by both "
+                          f"{picks[cpd_id]['curator']} and {curator}; "
+                          f"using {curator}", file=sys.stderr)
+                picks[cpd_id] = {
+                    'format': row.get('format', '').strip(),
+                    'structure': row.get('structure', '').strip(),
+                    'source_db': row.get('source_db', '').strip(),
+                    'source_id': row.get('source_id', '').strip(),
+                    'curator': curator,
+                    'date': row.get('date', '').strip(),
+                    'rationale': row.get('rationale', '').strip(),
+                }
+    return picks
+
+
+def derive_structures_from_override(override):
+    """Given a curator override row, parse its structure via RDKit and
+    return {'SMILE': str, 'InChI': str, 'InChIKey': str, 'formula': str,
+             'charge': str} -- all derived consistently from the override.
+    Returns None if RDKit can't parse the structure.
+    """
+    import re
+    try:
+        from rdkit import Chem, RDLogger
+        from rdkit.Chem import rdMolDescriptors
+        from rdkit.Chem.inchi import MolFromInchi, MolToInchi, InchiToInchiKey
+        RDLogger.DisableLog('rdApp.*')
+    except ImportError:
+        print("ERROR: RDKit not available; cannot derive structures "
+              "from curator overrides. Skipping override consult.",
+              file=sys.stderr)
+        return None
+
+    fmt = override['format']
+    struct = override['structure']
+    if fmt == 'InChI':
+        mol = MolFromInchi(struct)
+        if mol is None:
+            return None
+        inchi = struct
+    elif fmt == 'SMILE':
+        mol = Chem.MolFromSmiles(struct)
+        if mol is None:
+            return None
+        inchi = MolToInchi(mol)
+        if not inchi:
+            return None
+    else:
+        return None
+
+    smiles = Chem.MolToSmiles(mol, isomericSmiles=True, canonical=True)
+    inchikey = InchiToInchiKey(inchi)
+    # rdMolDescriptors.CalcMolFormula appends the net charge (e.g. "C40H66O7P2-2")
+    # but the Unique file stores formula and charge in separate columns,
+    # so strip a trailing charge marker.
+    formula_raw = rdMolDescriptors.CalcMolFormula(mol)
+    formula = re.sub(r'[+\-]\d*$', '', formula_raw)
+    charge = str(Chem.GetFormalCharge(mol))
+    return {
+        'SMILE': smiles,
+        'InChI': inchi,
+        'InChIKey': inchikey,
+        'formula': formula,
+        'charge': charge,
+    }
+
+
+CURATED_PICKS = load_curated_picks()
 
 #Load Compounds
 CompoundsHelper = Compounds()
@@ -129,7 +228,54 @@ for msid in sorted(MS_Aliases_Dict.keys()):
 
     if(len(Structs.keys())==0):
         continue
-    
+
+    #################################################################
+    ## Curator override consult: if this compound has a manual pick in
+    ## Biochemistry/Curation/overrides/structure_picks/<curator>.tsv,
+    ## use it directly and skip the cascade tiebreaker entirely.
+    ## All three formats (SMILE, InChIKey, InChI) are derived from the
+    ## override's structure via RDKit so they stay internally consistent.
+    #################################################################
+
+    if(msid in CURATED_PICKS):
+        override = CURATED_PICKS[msid]
+        derived = derive_structures_from_override(override)
+        if(derived is None):
+            print(f"WARN: cpd {msid} curator override ({override['curator']}) "
+                  f"could not be parsed by RDKit; falling back to cascade",
+                  file=sys.stderr)
+        else:
+            # Aggregate all aliases for this compound across all sources
+            override_aliases = set()
+            for src in MS_Aliases_Dict[msid]:
+                for alias in MS_Aliases_Dict[msid][src]:
+                    override_aliases.add(alias)
+            aliases_str = ";".join(sorted(override_aliases))
+            # Write the three structure rows to Unique using derived values
+            for stype in ("SMILE", "InChIKey", "InChI"):
+                unique_structs_file.write("\t".join((
+                    msid, stype, aliases_str,
+                    derived['formula'], derived['charge'],
+                    derived[stype])) + "\n")
+            # Record the pick rationale
+            reason = f"manual_curation:{override['curator']}"
+            pick_reasons_file.write("\t".join((
+                msid, override['format'], "Charged", reason,
+                override['structure'], aliases_str)) + "\n")
+            # Also report the underlying conflict (transparency) if any
+            # We pick the priority type/stage for the conflict report only.
+            for try_type in ("InChI", "SMILE"):
+                if(try_type in Structs and "Charged" in Structs[try_type]
+                        and len(Structs[try_type]["Charged"]) > 1):
+                    for structure in Structs[try_type]["Charged"]:
+                        for ext_id in Structs[try_type]["Charged"][structure]:
+                            structure_conflicts_file.write("\t".join((
+                                msid, try_type, "Charged", structure, ext_id,
+                                Structs[try_type]["Charged"][structure][ext_id])) + "\n")
+                    break
+            # Skip the cascade tiebreaker for this compound
+            continue
+
     #################################################################
     ## Prioritized which type and stage for the structure for comparison
     ## Priority Order is:


### PR DESCRIPTION
…consult)

Adds a mechanism for recording manual curator decisions about which source database's structure to use for compounds where sources conflict. Previously the picker in List_ModelSEED_Structures.py resolved such conflicts silently via a hard-coded DB priority cascade (KEGG > MetaCyc > ChEBI > Rhea), producing "connectivity_db_priority:X" pick reasons for 256 compounds. Those defaults are arbitrary and can be overwritten downstream (e.g. by the PubChem validation pipeline) without any record of a real decision.

New workflow:
- Curator runs Scripts/Structures/Curate_Structure_Pick.py <cpd_id>
- Script shows the current pick + all source candidates + names
- Curator selects one (or pastes a custom InChI/SMILES) and writes a one-line rationale
- Decision appended to Biochemistry/Curation/overrides/structure_picks/<curator>.tsv (per-curator file for easy git blame)

List_ModelSEED_Structures.py now consults these files at the start of each compound's processing. If an override exists:
- Parse the chosen structure via RDKit
- Derive SMILE / InChIKey / InChI / formula / charge consistently
- Skip the cascade tiebreaker entirely
- Record pick reason as "manual_curation:<curator>"
- Still write the underlying source conflicts to Structure_Conflicts.txt for transparency

Schema (7 columns, TSV):
  cpd_id  format  structure  source_db  source_id  date  rationale

No overrides are added in this commit; the directory Biochemistry/Curation/overrides/structure_picks/ is created empty via .gitkeep so it's present for first-time curators.

Verified end-to-end with cpd02168: without an override the picker records connectivity_db_priority:MetaCyc; with an override pointing to ChEBI's alternate enantiomer, the picker records manual_curation:<curator> and the Unique file gets ChEBI's structure derived consistently across all three format rows.