### PR TITLE
Canonicalize SMILES in picker output to be idempotent with Recanonica…

### DIFF
--- a/Scripts/Structures/List_ModelSEED_Structures.py
+++ b/Scripts/Structures/List_ModelSEED_Structures.py
@@ -109,6 +109,44 @@ def derive_structures_from_override(override):
 
 CURATED_PICKS = load_curated_picks()
 
+
+#################################################################
+## SMILES canonicalization (idempotent with Recanonicalize_SMILES.py)
+##
+## Every SMILES row this script writes -- to All_ModelSEED_Structures.txt
+## and to Unique_ModelSEED_Structures.txt -- is passed through the same
+## RDKit-canonical function that Recanonicalize_SMILES.py uses. This
+## makes the two scripts' outputs idempotent: running the picker followed
+## by Recanonicalize produces zero further changes.
+##
+## Import lazily-guarded so the picker still runs (with warnings) if
+## RDKit isn't installed; the SMILES would then be written as-is.
+#################################################################
+
+def _make_smiles_canonicalizer():
+    """Return a function s -> canonical(s) that never raises;
+    on parse failure it returns the input unchanged."""
+    try:
+        # Reuse the algorithm from Recanonicalize_SMILES.py in the same
+        # directory to guarantee identical output.
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        if script_dir not in sys.path:
+            sys.path.insert(0, script_dir)
+        from Recanonicalize_SMILES import canonical_smiles as _canon
+        def _fn(s):
+            if not s:
+                return s
+            new, status = _canon(s)
+            return new if status not in ('parse_failure', 'null_or_empty') else s
+        return _fn
+    except Exception as e:
+        print(f"WARN: could not load SMILES canonicalizer ({e}); "
+              f"picker will write SMILES as-is from sources.", file=sys.stderr)
+        return lambda s: s
+
+
+CANONICALIZE_SMILES = _make_smiles_canonicalizer()
+
 #Load Compounds
 CompoundsHelper = Compounds()
 Compounds_Dict = CompoundsHelper.loadCompounds()
@@ -195,12 +233,16 @@ for msid in sorted(MS_Aliases_Dict.keys()):
 
                         #################################################################
                         ## Write all structures to master 'All_ModelSEED_Strutures.txt'
+                        ## SMILES rows are canonicalized so this file's output stays
+                        ## idempotent with Recanonicalize_SMILES.py.
                         #################################################################
 
+                        structure_to_write = (CANONICALIZE_SMILES(structure)
+                                              if struct_type == "SMILE" else structure)
                         master_structs_file.write("\t".join([msid,struct_type,struct_stage,external_id,source,\
                                                                  formula_charge_dict['formula'],\
                                                                  formula_charge_dict['charge'],\
-                                                                 structure])+"\n")
+                                                                 structure_to_write])+"\n")
                         
                         #################################################################
                         ## Skip if curated structure designated to be ignored
@@ -386,15 +428,18 @@ for msid in sorted(MS_Aliases_Dict.keys()):
                         aliases[alias]=1
 
                 #################################################################
-                ## We write them to file
+                ## We write them to file (SMILES canonicalized to keep Unique
+                ## idempotent with Recanonicalize_SMILES.py)
                 #################################################################
 
+                structure_to_write = (CANONICALIZE_SMILES(structure)
+                                      if structure_type == "SMILE" else structure)
                 unique_structs_file.write("\t".join((msid,\
                                                      structure_type,\
                                                      ";".join(sorted(aliases)),\
                                                      formula_charge_dict['formula'],\
                                                      formula_charge_dict['charge'],\
-                                                     structure))+"\n")
+                                                     structure_to_write))+"\n")
 
         else:
 
@@ -640,15 +685,18 @@ for msid in sorted(MS_Aliases_Dict.keys()):
                         aliases[alias]=1
 
                 #################################################################
-                ## Finally, write to file
+                ## Finally, write to file (SMILES canonicalized to keep Unique
+                ## idempotent with Recanonicalize_SMILES.py)
                 #################################################################
 
+                structure_to_use_out = (CANONICALIZE_SMILES(structure_to_use)
+                                        if structure_type == "SMILE" else structure_to_use)
                 unique_structs_file.write("\t".join((msid,\
                                                      structure_type,\
                                                      ";".join(sorted(aliases)),\
                                                      formula_charge_dict['formula'],\
                                                      formula_charge_dict['charge'],\
-                                                     structure_to_use))+"\n")
+                                                     structure_to_use_out))+"\n")
                                         
     #################################################################
     ## Here we report the structural conflicts


### PR DESCRIPTION
…lize_SMILES.py

List_ModelSEED_Structures.py now applies RDKit canonical SMILES generation to every SMILE row it writes -- to both All_ModelSEED_Structures.txt and Unique_ModelSEED_Structures.txt. Previously the picker wrote raw source SMILES verbatim, so any subsequent Recanonicalize_SMILES.py pass would change ~618 compounds' SMILES rows even though the picker had just run (the two scripts produced different SMILES for the same molecule).

Now the picker's output IS canonical. Verified: after a full picker run, running Recanonicalize_SMILES.py reports 0 updates in Unique (36,844 rows checked) and 0 updates in All (105,302 rows checked). Fully idempotent.

Implementation:
- New _make_smiles_canonicalizer() helper imports canonical_smiles from Recanonicalize_SMILES.py (same directory) so both scripts use the identical 5-iteration cycle-detection algorithm.
- If RDKit isn't available, the picker logs a warning and writes SMILES as-is (does not fail).
- SMILES that RDKit cannot parse are left unchanged (~19 in Unique, 40 in All -- Fe-Mo cofactors, unusual salts, R-group templates; same set already known to Recanonicalize_SMILES.py).

Applied at the 3 SMILE write sites in the picker:
1. All-file per-source master row (line ~104)
2. Unique no-conflict path (line ~247)
3. Unique conflict-resolution path (line ~500)

The manual-curation override path (added in commit 348075e) already produced canonical SMILES via RDKit and needs no further change.

Runtime impact: picker went from ~10s to ~62s for a full run (canonicalizing 105K SMILES rows). Acceptable for a one-shot regeneration operation.