### PR TITLE
Reject PubChem structures that drop stereo info instead of correcting it

### DIFF
--- a/Scripts/Structures/Validate_PubChem_Structures.py
+++ b/Scripts/Structures/Validate_PubChem_Structures.py
@@ -651,6 +651,20 @@ def _check_stereo_compatibility(stored_struct, pubchem_struct):
     s_b, p_b = s_layers.get('b', ''), p_layers.get('b', '')
     if not s_t and not s_b:
         return True, "compatible (stored has no InChI stereo layers)"
+    # Info-preserving guard: if the canonical InChI specifies a stereo layer
+    # and PubChem's InChI omits it entirely, that is a strict information
+    # loss, not a correction. The existing inversion check below only
+    # iterates over SHARED stereocenters, so a fully-dropped layer
+    # silently passes through. (Example: cpd35693 coniferyl alcohol radical
+    # -- canonical had /b8-3+ specifying E geometry, PubChem returned no
+    # /b layer at all, current check found 0 inversions on the empty
+    # shared-bond set and accepted the loss.)
+    if s_t and not p_t:
+        return False, ("stereo_loss: canonical InChI has tetrahedral /t "
+                       "stereo layer, PubChem InChI has none")
+    if s_b and not p_b:
+        return False, ("stereo_loss: canonical InChI has bond /b "
+                       "(E/Z) stereo layer, PubChem InChI has none")
     inversions, checked = 0, 0
     if s_t and p_t:
         s_centers = {m.group(1): m.group(2)
@@ -675,6 +689,22 @@ def _check_stereo_compatibility(stored_struct, pubchem_struct):
     if inversions > 0:
         return False, (f"stereo_inversion: {inversions} of {checked} "
                        f"shared stereocenters have different configuration")
+    # Spec-loss guard: catch shared /t centers where canonical has specified
+    # config (+/-) and PubChem has unspecified (?). The existing inversion
+    # check uses regex r'(\d+)([+-])' which excludes ?-marked centers, so a
+    # partial spec loss silently passes the inversion check.
+    if s_t and p_t:
+        s_partial = {m.group(1): m.group(2)
+                     for m in re.finditer(r'(\d+)([+\-?])', s_t)}
+        p_partial = {m.group(1): m.group(2)
+                     for m in re.finditer(r'(\d+)([+\-?])', p_t)}
+        spec_losses = sum(1 for k in s_partial
+                          if s_partial[k] in ('+', '-')
+                          and p_partial.get(k) == '?')
+        if spec_losses:
+            return False, (f"stereo_loss: {spec_losses} shared /t "
+                           f"stereocenter(s) lost specificity (+/- to ?) "
+                           f"in PubChem InChI")
     # Enantiomer guard: InChI encodes relative configuration in the /t layer
     # and absolute configuration in the /m layer. A full enantiomer has an
     # IDENTICAL /t but a flipped /m, so the per-center /t comparison above sees


### PR DESCRIPTION
_check_stereo_compatibility previously compared shared /t (tetrahedral) and /b (bond) InChI stereo centers between the canonical InChI and PubChem's InChI, flagging any INVERSION as a rejection. Two failure modes silently passed:

  1. LAYER-ABSENT: PubChem's InChI omits the /t or /b layer entirely. The inversion loop iterated over shared centers only, so an empty shared set produced zero inversions and the "correction" was accepted -- turning a specified stereo into an unspecified one.

     Real example: cpd35693 (coniferyl alcohol radical) had canonical /b8-3+ specifying E geometry at the sinapyl double bond. PubChem returned an InChI with no /b layer. The pipeline accepted the replacement, quietly discarding the E/Z assignment.

  2. SHARED-CENTER SPEC LOSS: shared /t center goes from +/- in canonical to ? in PubChem. The inversion loop's regex r'(\d+)([+-])' excluded ?-marked centers from either set, so a specified-to-unspecified transition on a shared center produced zero inversions.

     Real examples: cpd03913, cpd03832 (both in the priority-scope compound set) each had specified /t stereocenters that PubChem returned as ? -- partial information loss that was previously accepted as "compatible".

Two new guards, both additive and ordered before the existing inversion check so they short-circuit early:

  - After the "no stereo layers" shortcut and before the inversion loop: reject when the canonical InChI has a /t or /b layer that PubChem's InChI lacks entirely.
  - After the inversion loop: reject when a shared /t center went from +/- to ? (partial spec loss).

Both rejections use the "stereo_loss:" prefix in the rejection reason so they group naturally in Phase 5 log analysis alongside the existing "stereo_inversion:" rejections. Curators who want to override on a per-compound basis can add the compound to
Biochemistry/Curation/ignores/ or use the existing structure_picks override mechanism.

Impact (measured in local rerun tree against fresh upstream/dev after applying these guards):
  - InChI-changed compounds: 67 -> 57 (10 previously-accepted stereo losses now rejected)
  - Confirmed no false positives in the 30 spec_gained_only and 15 added_centers compounds bulk-accepted earlier this cycle.