### PR TITLE
Methods: fill the abstention rate placeholder from the completed run

### DIFF
--- a/Papers/NAR_Update_2026/latex/sections/methods_council_direction.tex
+++ b/Papers/NAR_Update_2026/latex/sections/methods_council_direction.tex
@@ -1,5 +1,6 @@
 %% Direction assignment from reaction chemistry (LLM ensemble).
-%% \TBD values pending the full-database run, in progress.
+%% Run complete over all 45,644 reactions. The one remaining \TBD is the
+%% supplementary reference, pending final numbering.
 \subsection{Direction assignment from reaction chemistry}\label{sec:methods-council}
 
 Thermodynamic direction assignment is bounded by estimate coverage: a reaction
@@ -53,11 +54,11 @@ the per-reaction justification from each model and the auditor's objections,
 so individual assignments can be reviewed rather than accepted in aggregate.
 Two properties of the method bear on how the calls should be used. The
 ensemble commits to a direction far more readily than the thermodynamic rules
-do, abstaining on \TBD[pct]\% of reactions where the rules decline on a
-substantial fraction of the database, so it supplies calls where none
-currently exist rather than reproducing the ones that do. And its stated
-confidence does not distinguish its correct calls from its incorrect ones, so
-confidence is not a usable filter for downstream integration. A systematic
+do, abstaining on 1.7\% of the reaction set where the existing rules decline
+on 48.7\% of it, so it supplies calls where none currently exist rather than
+reproducing the ones that do. And its stated confidence does not distinguish
+its correct calls from its incorrect ones, so confidence is not a usable
+filter for downstream integration. A systematic
 evaluation against measured equilibrium constants, and against the
 model-level consequences of adopting these calls, is deferred to follow-up
 work.


### PR DESCRIPTION
Follow-up to #290. The full-database council run finished after that merged, so the `\TBD[pct]` placeholder can be replaced with the measured value.

The ensemble abstains on **1.7%** of the 45,644 reactions, against the existing rules declining on **48.7%** of them. Both halves of that contrast are now measured rather than one being a placeholder and the other "a substantial fraction".

Run summary, for context: 45,644 reactions, zero errors, no missing records. It supplies a direction for 22,010 of the 22,232 reactions the database currently cannot call.

The only remaining `\TBD` in the section is the supplementary reference, waiting on final numbering.